### PR TITLE
Update SEO Meta Fields Schema for Clarity

### DIFF
--- a/src/schemas/Schema.ts
+++ b/src/schemas/Schema.ts
@@ -9,11 +9,11 @@ const schema = defineType({
   fields: [
     {
       name: "nofollowAttributes",
-      title: "Index",
+      title: "Prevent Indexing",
       type: "boolean",
       initialValue: false,
       description:
-        "To prevent a URL from being indexed, you'll also need to select the true index on the tag.",
+        "Enable this option to prevent search engines from indexing this URL (applies a `noindex` tag).",
     },
     {
       name: "metaTitle",


### PR DESCRIPTION
**Changes Made:**

1. **Title and Description Changes:**
   - Changed the field title from "No Index" to "Prevent Indexing" to better represent its functionality.
   - Updated the description to clearly state: "Enable this option to prevent search engines from indexing this URL (applies a `noindex` tag)."

**Reason for Changes:**
I love this schema type, but in my personal experience, I could see how someone could find the title and description of `Index` confusing and somewhat contradictory. These updates provide clearer guidance to users on what the `nofollowAttributes` field does and prevent potential misunderstandings about indexing controls.

I’m open to feedback, so please let me know if you have any other thoughts or suggestions!